### PR TITLE
activate .ve before pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Assuming a unix based system with Python 3 installed:
 
 ```
 python3 -m venv .ve
-pip install -r requirements.txt
 source .ve/bin/activate
+pip install -r requirements.txt
 cd docs
 make dirhtml
 ```


### PR DESCRIPTION
Commands wrong way round in readme