### PR TITLE
Clarify country subdivisions in org list codes

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -17,6 +17,8 @@ Each **organisation list** code is made up of two parts: a jurisdiction code, an
 
 For any list which contains entries only from a given country, the `ISO 2-digit country code should be used <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements>`_.
 
+For any list which contains entries only from a given subdivision of a country, the ISO 2-digit country code, followed by underscore, followed by the `subdivision code should be used <https://en.wikipedia.org/wiki/ISO_3166-2>`_. (For example "CA_BC" would be used for British Columbia, Canada.) 
+
 For lists that contain entries from multiple countries, one of the following codes should be used (NOTE:  We rely here on the fact that in ISO 3166-1 the following alpha-2 codes can be user-assigned: AA, QM to QZ, XA to XZ, and ZZ. We avoid any widely used X codes. ).
 
 +--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
This clarification is needed since the inclusion of subdivision codes in organisation list codes is currently being handled in diverse ways, some of which make handling list codes more difficult.

This guidance edit aligns us with what has currently been done for [Canadian entries](http://org-id.guide/results?structure=all&coverage=CA&sector=all). (There are other lists that have used a different pattern, e.g. MX-CMX_CPA, but this is confusing since the CMX_CPA might refer to a [multilingual list name code](http://docs.org-id.guide/en/latest/metadata/#list-name-code).)

Making this change in the guidance means that we can move to a position where org list codes only ever contain one hyphen, making parsing simpler. So the organisation list code is:

[Jurisdiction code]-[List name code]

, where [Jurisdiction code] and [List name code] are each alpha-numeric strings that may also contain underscores but do not contain hyphens.

(See this [org-id comment](https://github.com/org-id/register/pull/502#issuecomment-1103707920) for background.)